### PR TITLE
fix: normalize shortcode to lowercase in `ShortcodeForm` and `SelectedUnitMapCard`

### DIFF
--- a/src/forms/ShortcodeForm.tsx
+++ b/src/forms/ShortcodeForm.tsx
@@ -19,7 +19,7 @@ interface IShortcodeFormProps {
 }
 
 export const ShortcodeForm: FC<IShortcodeFormProps> = ({ unitData }) => {
-  const currentShortcode = unitData.shortcode || "";
+  const currentShortcode = unitData.shortcode?.toLowerCase() || "";
   const [shortcode, setShortcode] = useState<string>(currentShortcode);
   const { plot_price } = useAaParams();
   const walletAddress = useSettingsStore((state) => state.walletAddress);
@@ -32,7 +32,7 @@ export const ShortcodeForm: FC<IShortcodeFormProps> = ({ unitData }) => {
   const isTaken = shortcode in existingShortcodes && existingShortcodes[shortcode] !== walletAddress;
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/[^A-Za-z0-9_-]/g, "").toUpperCase();
+    const value = e.target.value.replace(/[^A-Za-z0-9_-]/g, "").toLowerCase();
     setShortcode(value);
   };
 

--- a/src/pages/MainPage/components/SelectedUnitMapCard.tsx
+++ b/src/pages/MainPage/components/SelectedUnitMapCard.tsx
@@ -150,7 +150,7 @@ export const SelectedUnitMapCard: FC<ISelectedUnitMapCardProps> = ({ sceneType =
                 tooltipText="Shortcodes are used to send money via the wallet instead of using a full address"
                 loading={loading}
               >
-                {selectedMapUnit.shortcode}
+                {selectedMapUnit.shortcode.toLowerCase()}
               </InfoPanel.Item>
             ) : null}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Shortcodes are now consistently displayed and entered in lowercase throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->