### PR TITLE
feat: add Discord and Telegram bot URLs to appConfig and update BuyNewPlotCard and PrelaunchCard to use them

### DIFF
--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -4,6 +4,8 @@ export default {
   LAUNCH_DATE: import.meta.env.VITE_LAUNCH_DATE, // YYYY-MM-DD
   MAP_SCALE: 0.01, // 1:100, please do not change this value
   OG_IMAGE_URL: import.meta.env.VITE_OG_IMAGE_URL ?? "https://og-test.obby.space",
+  DISCORD_BOT_URL: "obyte:Ama48/uKO+/Tjv28zFKwElBO4SEQNuWAM1VPJkl4DTZO@obyte.org/bb#0000",
+  TELEGRAM_BOT_URL: "obyte:A1KwcOAZSWwBnXwa1BKfmhEP2yow1kaUuoi5A6HLOzJZ@obyte.org/bb#0000",
   ATTESTORS: !!import.meta.env.VITE_TESTNET
     ? {
         discord: "EJC4A7WQGHEZEKW6RLO7F26SAR4LAQBU",

--- a/src/pages/MainPage/components/BuyNewPlotCard.tsx
+++ b/src/pages/MainPage/components/BuyNewPlotCard.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import appConfig from "@/appConfig";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { BuyNewPlotForm } from "@/forms/BuyNewPlotForm";
 
 export const BuyNewPlotCard = () => (
@@ -11,6 +12,19 @@ export const BuyNewPlotCard = () => (
     <CardContent>
       <BuyNewPlotForm />
     </CardContent>
+
+    <CardFooter className="block text-xs text-muted-foreground">
+      Before buying, you need to link your Obyte address to your{" "}
+      <a href={appConfig.DISCORD_BOT_URL} className="text-link">
+        discord
+      </a>{" "}
+      and/or
+      <a href={appConfig.TELEGRAM_BOT_URL} className="text-link">
+        {" "}
+        telegram
+      </a>{" "}
+      usernames. This is necessary to notify you when you get a neighbor and become eligible for rewards.
+    </CardFooter>
   </Card>
 );
 

--- a/src/pages/MainPage/components/PrelaunchCard.tsx
+++ b/src/pages/MainPage/components/PrelaunchCard.tsx
@@ -1,8 +1,10 @@
-import appConfig from "@/appConfig";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import moment from "moment";
+
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { PrelaunchForm } from "@/forms/PrelaunchForm";
 import { useSettingsStore } from "@/store/settings-store";
-import moment from "moment";
+
+import appConfig from "@/appConfig";
 
 export const PrelaunchCard = () => {
   const { symbol } = useSettingsStore((state) => state);
@@ -20,6 +22,19 @@ export const PrelaunchCard = () => {
       <CardContent>
         <PrelaunchForm />
       </CardContent>
+
+      <CardFooter className="block text-xs text-muted-foreground">
+        Before buying, you need to link your Obyte address to your{" "}
+        <a href={appConfig.DISCORD_BOT_URL} className="text-link">
+          discord
+        </a>{" "}
+        and/or
+        <a href={appConfig.TELEGRAM_BOT_URL} className="text-link">
+          {" "}
+          telegram
+        </a>{" "}
+        usernames. This is necessary to notify you when you get a neighbor and become eligible for rewards.
+      </CardFooter>
     </Card>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added instructions and direct links in the Buy New Plot and Prelaunch cards for users to link their Obyte address with Discord and/or Telegram before purchasing.
- **Style**
  - Enhanced card layouts by including informative footers with relevant guidance and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->